### PR TITLE
Add support for Hori Real Arcade Pro VX-SA

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ xboxdrv 0.9.0 - (??/Aug/2011)
 * added Wing Commander configuration
 * added Duke Nukem 3D configuration
 * fixed incorrect axis being used in 4wayrest modifier
+* added Hori Real Arcade Pro VX-SA support
 
 
 xboxdrv 0.8.4 - (24/Jan/2012)

--- a/src/xpad_device.cpp
+++ b/src/xpad_device.cpp
@@ -68,6 +68,7 @@ XPadDevice xpad_devices[] = {
   { GAMEPAD_XBOX360,          0x0f0d, 0x000a, "Hori Co. DOA4 FightStick" },
   { GAMEPAD_XBOX360,          0x0f0d, 0x000d, "Hori Fighting Stick Ex2" },
   { GAMEPAD_XBOX360,          0x0f0d, 0x0016, "Hori Real Arcade Pro Ex" },
+  { GAMEPAD_XBOX360,          0x24c6, 0x5501, "Hori Real Arcade Pro VX-SA" },
   { GAMEPAD_XBOX360,          0x162e, 0xbeef, "Joytech Neo-Se Take2" },
   { GAMEPAD_XBOX360,          0x046d, 0xc21e, "Logitech F510" },
   { GAMEPAD_XBOX360,          0x046d, 0xc242, "Logitech ChillStream" },


### PR DESCRIPTION
Tested and functional against 0.8.4 but non-functional on master due to the same issue as https://github.com/Grumbel/xboxdrv/issues/20
