### PR TITLE
Remove -ansi to fix build problem with bluetooth.h

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -121,7 +121,8 @@ if 'BUILD' in env and env['BUILD'] == 'development':
 elif 'BUILD' in env and env['BUILD'] == 'custom':
     pass
 else:
-    env.Append(CPPFLAGS = ['-g', '-O3', '-Wall', '-ansi', '-pedantic'])
+    # -ansi removed for now, see above
+    env.Append(CPPFLAGS = ['-g', '-O3', '-Wall', '-pedantic'])
 
 env.ParseConfig("pkg-config --cflags --libs dbus-glib-1 | sed 's/-I/-isystem/g'")
 env.ParseConfig("pkg-config --cflags --libs glib-2.0 | sed 's/-I/-isystem/g'")


### PR DESCRIPTION
This removes the -ansi flag in non-development/custom builds. For reference, see 47d641efd204eecc5979813eb24c2fff09984d3a.
