### PR TITLE
Adding support for Mad Catz Street Fighter IV FightStick TE

### DIFF
--- a/src/xpad_device.cpp
+++ b/src/xpad_device.cpp
@@ -64,6 +64,7 @@ XPadDevice xpad_devices[] = {
   { GAMEPAD_XBOX360,          0x0738, 0xb726, "Mad Catz Xbox controller - MW2" },
   { GAMEPAD_XBOX360,          0x0738, 0xf738, "Super SFIV FightStick TE S" },
   { GAMEPAD_XBOX360,          0x0738, 0x4718, "Mad Catz Street Fighter IV FightStick SE" },
+  { GAMEPAD_XBOX360,          0x0738, 0x4738, "Mad Catz Street Fighter IV FightStick TE" },
   { GAMEPAD_XBOX360,          0x0738, 0xbeef, "Mad Catz Xbox 360 Controller" },
   { GAMEPAD_XBOX360,          0x0f0d, 0x000a, "Hori Co. DOA4 FightStick" },
   { GAMEPAD_XBOX360,          0x0f0d, 0x000d, "Hori Fighting Stick Ex2" },


### PR DESCRIPTION
When I do a usb-devices, I get:

T:  Bus=01 Lev=02 Prnt=02 Port=01 Cnt=02 Dev#= 10 Spd=12  MxCh= 0
D:  Ver= 2.00 Cls=ff(vend.) Sub=ff Prot=ff MxPS= 8 #Cfgs=  1
P:  Vendor=0738 ProdID=4738 Rev=04.90
S:  Manufacturer=Mad Catz, Inc.
S:  Product=Street Fighter IV FightStick TE
S:  SerialNumber=0FA88050
C:  #Ifs= 4 Cfg#= 1 Atr=a0 MxPwr=500mA
I:  If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=5d Prot=01 Driver=(none)
I:  If#= 1 Alt= 0 #EPs= 4 Cls=ff(vend.) Sub=5d Prot=03 Driver=(none)
I:  If#= 2 Alt= 0 #EPs= 1 Cls=ff(vend.) Sub=5d Prot=02 Driver=(none)
I:  If#= 3 Alt= 0 #EPs= 0 Cls=ff(vend.) Sub=fd Prot=13 Driver=(none)

After making the changes to xpad_device.cpp, it now successfully recognizes the stick:

$ ./xboxdrv -L
 id | wid | idVendor | idProduct | Name
----+-----+----------+-----------+--------------------------------------
  0 |   0 |   0x0738 |    0x4738 | Mad Catz Street Fighter IV FightStick TE
