### PR TITLE
Button event exec: Double fork to avoid zombies

### DIFF
--- a/src/buttonevent/exec_button_event_handler.cpp
+++ b/src/buttonevent/exec_button_event_handler.cpp
@@ -21,6 +21,7 @@
 #include <boost/tokenizer.hpp>
 #include <errno.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "log.hpp"
 
@@ -45,9 +46,17 @@ ExecButtonEventHandler::ExecButtonEventHandler(const std::vector<std::string>& a
 void
 ExecButtonEventHandler::send(bool value)
 {
-  if (value)
+  if (!value)
   {
+    return;
+  }
+
+  pid_t tmp_pid = fork();
+  if (tmp_pid == 0)
+  {
+    // Double fork to reap the child and disown the execed process
     pid_t pid = fork();
+
     if (pid == 0)
     {
       char** argv = static_cast<char**>(malloc(sizeof(char*) * (m_args.size() + 1)));
@@ -63,7 +72,11 @@ ExecButtonEventHandler::send(bool value)
         _exit(EXIT_FAILURE);
       }
     }
+
+    _exit(EXIT_SUCCESS);
   }
+
+  waitpid(tmp_pid, NULL, 0);
 }
 
 std::string


### PR DESCRIPTION
When using the `exec:` button handler, processes will be forked, but are never reaped. So you will end up with a lot of zombie processes.

This fixes the problem by double forking and reaping the first child process, thus the `exec`d process is disowned and taken by the highest process in the namespace (usually `init`).

The other solution would be to periodically reap finished processes, but why do that when we can just let init handle it?
