### PR TITLE
Added support for Gamestop BB-070 Xbox 360 clone

### DIFF
--- a/src/xpad_device.cpp
+++ b/src/xpad_device.cpp
@@ -82,6 +82,7 @@ XPadDevice xpad_devices[] = {
   { GAMEPAD_XBOX360,          0x0e6f, 0x0201, "Pelican TSZ360 Pad" },
   { GAMEPAD_XBOX360,          0x0e6f, 0x0213, "Afterglow Gamepad for Xbox 360" },
   { GAMEPAD_XBOX360,          0x0e6f, 0x0401, "Logic3 Controller" },
+  { GAMEPAD_XBOX360,          0x0e6f, 0x0301, "Logic3 Controller" },
   { GAMEPAD_XBOX360,          0x12ab, 0x0301, "PDP AFTERGLOW AX.1" },
   { GAMEPAD_XBOX360_GUITAR,   0x1430, 0x4748, "RedOctane Guitar Hero X-plorer" },
   { GAMEPAD_XBOX360_GUITAR,   0x1bad, 0x0002, "Harmonix Guitar for Xbox 360" },


### PR DESCRIPTION
I already tested this trivial change that adds support for another Xbox 360 controller clone, in particular it regards the latest Gamestop clone. Everything seems to work as expected and perfectly.
