### PR TITLE
Reset outputs on config slot changes to prevent stuck keys/axes

### DIFF
--- a/src/message_processor.cpp
+++ b/src/message_processor.cpp
@@ -132,7 +132,12 @@ MessageProcessor::set_config(int num)
 {
   if (m_config)
   {
+    // reset old mapping to zero to not get stuck keys/axis
+    m_config->get_config()->get_emitter().reset_all_outputs();
+
     m_config->set_current_config(num);
+
+    log_info("switched to config: " << m_config->get_current_config());
   }
 }
 


### PR DESCRIPTION
When using the config slot toggle button (e.g. the guide button), the code resets output values so that buttons and axes don't get stuck at weird values.  When a config slot change request comes via dbus, it doesn't, so weird stuff happens if any of the axes are changing around.  This change just replicates the behavior of the toggle button in the config slot setting.
