### PR TITLE
Clarified that Xbox One controllers are not supported in the README.

### DIFF
--- a/README
+++ b/README
@@ -7,6 +7,8 @@ support for Xbox1 gamepads, Xbox360 USB gamepads and Xbox360 wireless
 gamepads. The Xbox360 guitar and some Xbox1 dancemats might work too.
 The Xbox 360 racing wheel is not supported, but shouldn't be to hard
 to add if somebody is interested.
+Controllers for the Xbox One (third generation console) are not
+supported.
 
 Some basic support for the Xbox360 Chatpad on USB controller is
 provided, Chatpad on wireless ones is not supported. The headset is


### PR DESCRIPTION
Since the README uses the ambiguous term Xbox1 in reference to the first generation console, I added a clarification so that new users do not make the same mistake I did, thinking this driver will work for the Xbox One (third generation console).
