### PR TITLE
Update xpad_device.cpp

### DIFF
--- a/src/xpad_device.cpp
+++ b/src/xpad_device.cpp
@@ -103,6 +103,7 @@ XPadDevice xpad_devices[] = {
   { GAMEPAD_XBOX360,          0x1689, 0xfd00, "Razer Onza" },
   { GAMEPAD_XBOX360,          0x1689, 0xfd01, "Razer Onza Tournament Edition" },
   { GAMEPAD_XBOX360,          0x1532, 0x0037, "Razer Sabertooth" },
+  { GAMEPAD_XBOX360,          0x24c6, 0x5d04, "Razer Sabertooth Elite" },
   { GAMEPAD_XBOX360,          0x12ab, 0x0004, "DDR Universe 2 Mat" },
   { GAMEPAD_XBOX360,          0x15e4, 0x3f0a, "Xbox Airflo wired controller" },
   { GAMEPAD_XBOX360,          0x24c6, 0x5300, "Power A Mini Pro Elite Glow" },


### PR DESCRIPTION
Add support for Razer Sabertooth Elite.
