### PR TITLE
Use the appropriate pkg-config via the exported variable

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -86,6 +86,7 @@ opts.Add('LINKFLAGS', 'Linker Compiler flags')
 opts.Add('CC', 'C Compiler')
 opts.Add('CXX', 'C++ Compiler')
 opts.Add('BUILD', 'Build type: release, custom, development')
+opts.Add('PKG_CONFIG', 'pkg-config helper tool', 'pkg-config')
 
 opts.Update(env)
 Help(opts.GenerateHelpText(env))
@@ -114,11 +115,11 @@ elif 'BUILD' in env and env['BUILD'] == 'custom':
 else:
     env.Append(CPPFLAGS = ['-g', '-O3', '-Wall', '-ansi', '-pedantic'])
 
-env.ParseConfig("pkg-config --cflags --libs dbus-glib-1 | sed 's/-I/-isystem/g'")
-env.ParseConfig("pkg-config --cflags --libs glib-2.0 | sed 's/-I/-isystem/g'")
-env.ParseConfig("pkg-config --cflags --libs gthread-2.0 | sed 's/-I/-isystem/g'")
-env.ParseConfig("pkg-config --cflags --libs libusb-1.0 | sed 's/-I/-isystem/g'")
-env.ParseConfig("pkg-config --cflags --libs libudev | sed 's/-I/-isystem/g'")
+env.ParseConfig(env['PKG_CONFIG'] + " --cflags --libs dbus-glib-1 | sed 's/-I/-isystem/g'")
+env.ParseConfig(env['PKG_CONFIG'] + " --cflags --libs glib-2.0 | sed 's/-I/-isystem/g'")
+env.ParseConfig(env['PKG_CONFIG'] + " --cflags --libs gthread-2.0 | sed 's/-I/-isystem/g'")
+env.ParseConfig(env['PKG_CONFIG'] + " --cflags --libs libusb-1.0 | sed 's/-I/-isystem/g'")
+env.ParseConfig(env['PKG_CONFIG'] + " --cflags --libs libudev | sed 's/-I/-isystem/g'")
 
 f = open("VERSION")
 package_version = f.read()


### PR DESCRIPTION
Fixes build issue in cross compiling environments (e.g. when the pkg-config command is prefixed, like x86_64-pc-linux-gnu-pkg-config). Defaults to pkg-config if the variable is not set.

[...]
scons --config=cache --jobs 5 CFLAGS=-pipe -O2 -march=native CXXFLAGS=-pipe -O2 -march=native -pipe -O2 LDFLAGS= AR=x86_64-pc-linux-gnu-ar CC=x86_64-pc-linux-gnu-gcc CXX=x86_64-pc-linux-gnu-g++ PKG_CONFIG=x86_64-pc-linux-gnu-pkg-config
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
/bin/sh: pkg-config: command not found
/bin/sh: pkg-config: command not found
/bin/sh: pkg-config: command not found
/bin/sh: pkg-config: command not found
/bin/sh: pkg-config: command not found
x86_64-pc-linux-gnu-g++ -o src/main/main.o -c -pipe -O2 -march=native -pipe -O2 -g -O3 -Wall -ansi -pedantic -DPACKAGE_VERSION='"0.8.5"' -Isrc src/main/main.cpp
x86_64-pc-linux-gnu-g++ -o src/arg_parser.o -c -pipe -O2 -march=native -pipe -O2 -g -O3 -Wall -ansi -pedantic -DPACKAGE_VERSION='"0.8.5"' -Isrc src/arg_parser.cpp
x86_64-pc-linux-gnu-g++ -o src/axis_event.o -c -pipe -O2 -march=native -pipe -O2 -g -O3 -Wall -ansi -pedantic -DPACKAGE_VERSION='"0.8.5"' -Isrc src/axis_event.cpp
x86_64-pc-linux-gnu-g++ -o src/axis_filter.o -c -pipe -O2 -march=native -pipe -O2 -g -O3 -Wall -ansi -pedantic -DPACKAGE_VERSION='"0.8.5"' -Isrc src/axis_filter.cpp
x86_64-pc-linux-gnu-g++ -o src/axis_map.o -c -pipe -O2 -march=native -pipe -O2 -g -O3 -Wall -ansi -pedantic -DPACKAGE_VERSION='"0.8.5"' -Isrc src/axis_map.cpp
In file included from src/main/main.cpp:19:0:
src/xboxdrv.hpp:22:20: fatal error: libusb.h: No such file or directory
 #include <libusb.h>
                    ^
compilation terminated.
[...]