### PR TITLE
fix build error (boos/strong_typedef.hpp is deprecated)

### DIFF
--- a/src/symbols/name.hpp
+++ b/src/symbols/name.hpp
@@ -20,7 +20,7 @@
 #define HEADER_XBOXDRV_SYMBOLS_NAME_HPP
 
 #include <string>
-#include <boost/strong_typedef.hpp>
+#include <boost/serialization/strong_typedef.hpp>
 #include <iostream>
 
 #include "symbols/environment.hpp"


### PR DESCRIPTION
now moved to boost/serialization/strong_typedef.hpp