### PR TITLE
Added alternative Afterglow AX.1 id

### DIFF
--- a/src/xpad_device.cpp
+++ b/src/xpad_device.cpp
@@ -88,6 +88,7 @@ XPadDevice xpad_devices[] = {
   { GAMEPAD_XBOX360,          0x0e6f, 0x0201, "Pelican PL-3601 'TSZ' Wired Xbox 360 Controller" },
   { GAMEPAD_XBOX360,          0x0e6f, 0x0105, "HSM3 Xbox360 dancepad" },
   { GAMEPAD_XBOX360,          0x0e6f, 0x0113, "Afterglow AX.1 Gamepad for Xbox 360" },
+  { GAMEPAD_XBOX360,          0x0e6f, 0x0413, "Afterglow AX.1 Gamepad for Xbox 360" },
   { GAMEPAD_XBOX360,          0x0e6f, 0x0213, "Afterglow Gamepad for Xbox 360" },
   { GAMEPAD_XBOX360,          0x0e6f, 0x0401, "Logic3 Controller" },
   { GAMEPAD_XBOX360,          0x0e6f, 0x0301, "Logic3 Controller" },


### PR DESCRIPTION
Added another id for Afterglow AX.1 Xbox 360 controller.
Tested and works on raspberry pi (retropie 4.1.7).

Since 0113, 0213 and 0413 are all versions of pretty much the same controller, maybe guess 0313 should also be added?
