### PR TITLE
Update usb_controller.cpp

### DIFF
--- a/src/usb_controller.cpp
+++ b/src/usb_controller.cpp
@@ -279,6 +279,7 @@ USBController::on_read_data(libusb_transfer* transfer)
     log_error("USB read failure: " << transfer->length << ": " << usb_transfer_strerror(transfer->status));
     m_transfers.erase(transfer);
     libusb_free_transfer(transfer);
+    send_disconnect();
   }
 }
 


### PR DESCRIPTION
I had the error : 
"[ERROR] USBController::on_read_data(): USB read failure: 32: LIBUSB_TRANSFER_ERROR"
and then I could not reconnect my controller.

Adding send_disconnect(); solved this.
