### PR TITLE
Fix issue no. #186: Allow no USB transfer in limbo

### DIFF
--- a/src/usb_controller.cpp
+++ b/src/usb_controller.cpp
@@ -252,33 +252,27 @@ USBController::on_read_data(libusb_transfer* transfer)
     {
       submit_msg(msg);
     }
-
-    int ret;
-    ret = libusb_submit_transfer(transfer);
-    if (ret != LIBUSB_SUCCESS) // could also check for LIBUSB_ERROR_NO_DEVICE
-    {
-      log_error("failed to resubmit USB transfer: " << usb_strerror(ret));
-      m_transfers.erase(transfer);
-      libusb_free_transfer(transfer);
-      send_disconnect();
-    }
-  }
-  else if (transfer->status == LIBUSB_TRANSFER_CANCELLED)
-  {
-    m_transfers.erase(transfer);
-    libusb_free_transfer(transfer);
   }
   else if (transfer->status == LIBUSB_TRANSFER_NO_DEVICE)
   {
     m_transfers.erase(transfer);
     libusb_free_transfer(transfer);
     send_disconnect();
+    return;
   }
   else
   {
     log_error("USB read failure: " << transfer->length << ": " << usb_transfer_strerror(transfer->status));
+  }
+
+  int ret;
+  ret = libusb_submit_transfer(transfer);
+  if (ret != LIBUSB_SUCCESS) // could also check for LIBUSB_ERROR_NO_DEVICE
+  {
+    log_error("failed to resubmit USB transfer: " << usb_strerror(ret));
     m_transfers.erase(transfer);
     libusb_free_transfer(transfer);
+    send_disconnect();
   }
 }
 


### PR DESCRIPTION
After a USB transfer error, either retry or properly disconnect if the
device is no longer found.
