### PR TITLE
Numerous grammar and markup fixes

### DIFF
--- a/doc/xboxdrv-daemon.1
+++ b/doc/xboxdrv-daemon.1
@@ -73,7 +73,7 @@ Note that you can't dynamically reconfigurabilty xboxdrv
 when you launch it automatically via the daemon, so using this
 daemon isn't generally recommend.
 .PP
-When you want configurability and automatic launching, it is recomment
+When you want configurability and automatic launching, it is recommended
 that you write little startup scripts for your games, such as this:
 .PP
 .nf

--- a/doc/xboxdrv.1
+++ b/doc/xboxdrv.1
@@ -47,7 +47,7 @@ option \*(T<\fB\-\-evdev\fR\*(T> below for more information.
 When a \*(T<\fBCOMMAND\fR\*(T> is provided xboxdrv will launch
 that application and be running till that application exits.
 This is a convenience function to make it easier to use xboxdrv
-in wrapper scripts. See the section
+in wrapper scripts. See section
 [Writing Start-Up Scripts for Games]
 for more information.
 .SH OPTIONS
@@ -56,14 +56,14 @@ for more information.
 \*(T<\fB\-h\fR\*(T>, \*(T<\fB\-\-help\fR\*(T>
 Display help text and exit.
 .TP 
--V, --version
+\*(T<\fB\-V\fR\*(T>, \*(T<\fB\-\-version\fR\*(T>
 Print the version number and exit.
 .TP 
 \*(T<\fB\-v\fR\*(T>, \*(T<\fB\-\-verbose\fR\*(T>
 Print verbose messages.
 .TP 
 \*(T<\fB\-\-debug\fR\*(T>
-Print even more verbose messages then \*(T<\fB\-\-verbose\fR\*(T>.
+Print even more verbose messages than \*(T<\fB\-\-verbose\fR\*(T>.
 .TP 
 \*(T<\fB\-s\fR\*(T>, \*(T<\fB\-\-silent\fR\*(T>
 Do not display controller events on the terminal. For
@@ -86,11 +86,11 @@ increase the priority.
 
 This option is deprecated,
 use \fBchrt\fR(1)
-instead to achive the same effect.
+instead to achieve the same effect.
 .SS "LIST OPTIONS"
 .TP 
 \*(T<\fB\-\-help\-led\fR\*(T>
-List possible values for the led.
+List possible values for the LED.
 .TP 
 \*(T<\fB\-\-help\-devices\fR\*(T>
 List supported devices.
@@ -145,7 +145,7 @@ files. Regular key/value pairs must go into the
 Key names have for most part the same name as command
 line options. Command line options that take a list of
 input mappings (--ui-buttonmap, --ui-axismap,
---evdev-absmap, ...) can be split of into their own
+--evdev-absmap, ...) can be split off into their own
 section for better readability.
 
 The \*(T<\fIexamples/\fR\*(T> directory contains
@@ -257,7 +257,7 @@ disabled and
 auto. The default is
 auto, which will detect the
 appropriate bus type depending on if xboxdrv is run as
-root (system or as user
+root (system) or as user
 (session). Running with
 disabled will disable D-Bus support
 completely.
@@ -267,14 +267,14 @@ Launches \fIEXE\fR
 when a controller gets connected. As arguments
 "\fIBUSDEV\fR:\fIDEVNUM\fR",
 "\fIidVendor\fR:\fIidProduct\fR",
-"\fINAME\fR are provided.
+"\fINAME\fR" are provided.
 .TP 
 \*(T<\fB\-\-on\-disconnect\fR\*(T> \fIEXE\fR
 Launches \fIEXE\fR
 when a controller gets disconnected. As arguments
 "\fIBUSDEV\fR:\fIDEVNUM\fR",
 "\fIidVendor\fR:\fIidProduct\fR",
-"\fINAME\fR are provided.
+"\fINAME\fR" are provided.
 .SS "DEVICE OPTIONS"
 .TP 
 \*(T<\fB\-L\fR\*(T>, \*(T<\fB\-\-list\-controller\fR\*(T>
@@ -349,7 +349,7 @@ unloading it.
 \*(T<\fB\-\-generic\-usb\-spec\fR\*(T> \fINAME=VALUE,...\fR
 Allows to specify from which
 endpoint \*(T<\fBgeneric\-usb\fR\*(T> will read. The
-spec as the form
+spec has the form
 of \fINAME=VALUE,...\fR. Allowed values are:
 .RS 
 .TP 
@@ -404,7 +404,7 @@ events from that device. This is done to avoid confusing
 applications, as otherwise an app would receive every
 event twice, once from the original device and once from
 the virtual xboxdrv one. In some cases this behaviour is
-undesired, such when mapping only an otherwise
+undesired, such as when mapping only an otherwise
 unhandled subset of keys of an device, i.e. mapping the
 multimedia keys on a keyboard, so this option turns the
 grab off.
@@ -574,7 +574,7 @@ proper keymapping for any of the umlauts and special
 characters.
 .TP 
 \*(T<\fB\-\-chatpad\-no\-init\fR\*(T>
-This will start chatpad support with out sending the
+This will start chatpad support without sending the
 init sequence, thus potentially avoiding crashing the
 controller if xboxdrv is started multiple times.
 .TP 
@@ -702,14 +702,14 @@ pressing the ui-toggle button (defaults to guide).
 
 The above configuration would install mouse emulation as
 first configuration and a simple joystick emulation as
-second configuration. Allowing toggling between mouse
+second configuration allowing toggling between mouse
 emulation and joystick handling by pressing the guide
 button.
 
-Not that \*(T<\fB\-\-next\-config\fR\*(T> is currently limited
+Note that \*(T<\fB\-\-next\-config\fR\*(T> is currently limited
 to only configurations done
 with \*(T<\fB\-\-ui\-buttonmap\fR\*(T>
-and \*(T<\fB\-\-ui\-axismap\fR\*(T>, autofire, throttle
+and \*(T<\fB\-\-ui\-axismap\fR\*(T>; autofire, throttle
 emulation, deadzones and all other things can currently
 not be switched at runtime.
 .TP 
@@ -724,10 +724,10 @@ between configurations.
 \*(T<\fB\-\-modifier \fR\*(T>\fIMOD\fR
 Add a modifier to the modifier stack, see
 [Modifier] for
-a full list of possible modifier.
+a full list of possible modifiers.
 .TP 
 \*(T<\fB\-\-timeout \fR\*(T>\fIMSEC\fR
-Specify the number of miliseconds that xboxdrv will wait
+Specify the number of milliseconds that xboxdrv will wait
 for events from the controller before moving on and
 processing things like auto-fire or relative-axis.
 Default value is 10, smaller values will give you a
@@ -748,7 +748,7 @@ If you want all face buttons send out A button events:
 \*(T<$ xboxdrv \-\-buttonmap B=A,X=A,Y=A\*(T>
 .fi
 
-Possible button names are (aliases are in parenthesis):
+Possible button names are (aliases are in parentheses):
 
 \fBButton Names\fR
 .TS
@@ -827,12 +827,12 @@ If you want to swap the left and right stick start with:
 
 Possible axis names are: x1, y1, x2, y2, lt, rt
 
-Swaping lt or rt with x1, y1, x2, y2 will not work properly, since
+Swapping lt or rt with x1, y1, x2, y2 will not work properly, since
 their range is different.
 
 Just like with \*(T<\fB\-\-ui\-axismap\fR\*(T> you can add axis filter to each axis.
 .SS "MODIFIER PRESET CONFIGURATION OPTIONS"
-The options in this sections are sortcuts
+The options in this section are shortcuts
 for \*(T<\fB\-\-modifier\fR\*(T> options.
 Unlike \*(T<\fB\-\-modifier\fR\*(T> they are not order
 depended, but have a predefined order that is used no matter
@@ -840,7 +840,7 @@ the order in which the options are given.
 .TP 
 \*(T<\fB\-\-autofire BUTTON=FREQUENCY,...\fR\*(T>
 Autofire mapping allows you to let a button automatically fire with a
-given frequency in miliseconds:
+given frequency in milliseconds:
 
 .nf
 \*(T<$ xboxdrv \-\-autofire A=250\*(T>
@@ -854,7 +854,7 @@ as autofire while another one, emitting the same signal, acts normally.
 .fi
 .TP 
 \*(T<\fB\-\-axis\-sensitivty \fR\*(T>\fIAXIS=SENSITIVITY\fR,...
-The sensitive of an axis can be adjusted via --axis-sensitivty:
+The sensitivity of an axis can be adjusted via --axis-sensitivty:
 
 .nf
 \*(T<$ xboxdrv \-\-axis\-sensitivty X1=\-1.0,Y1=\-1.0\*(T>
@@ -906,7 +906,7 @@ stick is only moved half the way.
 .TP 
 \*(T<\fB\-\-deadzone \fR\*(T>\fINUM\fR
 The deadzone is the area at which the sticks do not report any
-events. The default is zero, which gives the best sensitifity but
+events. The default is zero, which gives the best sensitivity but
 might also cause trouble in some games in that the character or camera
 might move without moving the stick. To fix this one has to set the
 value to something higher:
@@ -947,7 +947,7 @@ character instead of your viewpoint.
 .TP 
 \*(T<\fB\-\-four\-way\-restrictor\fR\*(T>
 The \*(T<\fB\-\-four\-way\-restrictor\fR\*(T> option allows to
-limit the movement on both analogsticks to only four
+limit the movement on both analog sticks to only four
 directions (up, down, left, right), the diagonals (up/left,
 up/right, down/left, down/right) are filtered out from the
 output. This option is useful for games such as Tetris, that
@@ -975,7 +975,7 @@ movement so that the distance to the center never gets
 beyond 1. This means that when you have the controller
 at the top/left the value reported is (0.7, 0.7)
 (i.e. length 1, angle 45) instead of (1,1). This
-behaviour is different then most classic PC joysticks,
+behaviour is different from most classic PC joysticks,
 which had a square range and would report (1,1) when
 hold in the top/left corner.
 
@@ -1002,18 +1002,18 @@ The DPad sends button instead of axis events.
 \*(T<\fB\-\-dpad\-only\fR\*(T>
 Both sticks are ignored, only the DPad sends out axis
 events. Useful for games that might get confused by
-additional analog axis. Combining this option
-with \*(T<\fB\-\-trigger\-as\-button\fR\*(T> is recommend
+additional analog axes. Combining this option
+with \*(T<\fB\-\-trigger\-as\-button\fR\*(T> is recommended
 in most situations.
 .TP 
 \*(T<\fB\-\-guitar\fR\*(T>
 Sets a predefined button and axis mapping for use with
 guitar controllers. This mainly gets rid of a few
-unnecessary buttons and axis not used by a guitar
+unnecessary buttons and axes not used by a guitar
 controller.
 .TP 
 \*(T<\fB\-m, \-\-mouse\fR\*(T>
-Lets the controller act as a mouse. It is indendical to:
+Lets the controller act as a mouse. It is indentical to:
 
 .nf
 \*(T<$ xboxdrv \e
@@ -1069,10 +1069,10 @@ device, while ABS_X events would go to a virtual
 joystick device and KEY_ESC would go to a virtual
 keyboard device.
 
-To make sure sure that a mouse, keyboard or joystick
+To make sure that a mouse, keyboard or joystick
 device is properly detected by Xorg, the kernel or
-libraries such SDL xboxdrv will insert extra dummy
-events. For example a mouse device needs REL_X and REL_Y
+libraries such as SDL, xboxdrv will insert extra dummy
+events. For example, a mouse device needs REL_X and REL_Y
 events to be detected as such, but a configuration that
 only wants to emulate the mouse buttons won't provide
 those, thus xboxdrv will add them automatically.
@@ -1096,7 +1096,7 @@ matches everything.
 \*(T<\fB\-\-device\-usbid VENDOR:PRODUCT:VERSION:BUS\fR\*(T>
 Changes the vendor, product, version and bus id that the
 device will have. The last two arguments are optional.
-This options acts the same as
+This option acts the same as
 --device-usbids \fICURRENTSLOT\fR.auto=\fIVENDOR:PRODUCT:VERSION:BUS\fR
 .TP 
 \*(T<\fB\-\-device\-usbids TYPE.SLOT=VENDOR:PRODUCT:VERSION:BUS,...\fR\*(T>
@@ -1110,9 +1110,9 @@ matches everything.
 .TP 
 \*(T<\fB\-\-ui\-clear\fR\*(T>
 Removes all uinput mappings and will leave the driver in
-a blank state and only map those things you added
+a blank state and only map the things you added
 yourself. If you only want to get rid of individual
-buttons you can use the 'void' event.
+buttons, you can use the 'void' event.
 .TP 
 \*(T<\fB\-\-ui\-buttonmap\fR\*(T> \fIUIBUTTONSPEC,...\fR
 .nf
@@ -1129,14 +1129,14 @@ REPEAT       = NUMBER ;
 DEVICEID     = NUMBER ;\*(T>
 .fi
 
-Allows you to change the event code that is send to the
+Allows you to change the event code that is sent to the
 kernel for buttons. The usage is similar to the normal button
 mapping, except that the right hand side is an event name from
 \*(T<\fI/usr/include/linux/input.h\fR\*(T>. You can
 use all \fBKEY_\fR or \fBBTN_\fR 
 codes for \*(T<\fB\-\-ui\-buttonmap\fR\*(T>.
 
-If the right hand side is left empty all the supplied
+If the right hand side is left empty, all the supplied
 filters will be added to the already existing button
 binding instead of a new one.
 
@@ -1153,12 +1153,12 @@ by the X11 keymap and will often not report what you
 expect in case you use a keymap that is different then
 your keyboard (i.e. dvorak on a qwerty keyboard).
 
-A full list of valid X11 keysyms can be optained
+A full list of valid X11 keysyms can be obtained
 with \*(T<\fB\-\-help\-x11keysym\fR\*(T>.
 
 For joystick buttons there is in addition to the \fBBTN_JOYSTICK\fR, \fBBTN_X\fR,
 etc. macros the special name \fBJS_$NUM\fR, which sets the given button to
-the $NUMS joystick button, i.e.:
+the $NUMS joystick button, e.g.:
 
 .nf
 \*(T<$ xboxdrv \-\-ui\-clear \-\-ui\-buttonmap A=JS_0,B=JS_1\*(T>
@@ -1168,7 +1168,7 @@ Note that this will only work if no other joystick
 button ids are in the way.
 
 You can also map a button to a \fBREL_\fR
-event. In that case you can supply additional paramaters in the form of:
+event. In that case you can supply additional parameters in the form of:
 
 .nf
 \*(T<$ xboxdrv \-\-ui\-buttonmap X=REL_???:VALUE:REPEAT\*(T>
@@ -1177,7 +1177,7 @@ event. In that case you can supply additional paramaters in the form of:
 \fIVALUE\fR gives the value of the event (default: 10)
 
 \fIREPEAT\fR
-gives the number of milisecond to pass before the event
+gives the number of milliseconds to pass before the event
 is fired again (default: 5)
 
 The special 'void' event allows you to clear any
@@ -1188,7 +1188,7 @@ number of buttons.
 You can also prepend a device_id to the UIBUTTONSPEC
 which allows you to create multiple uinput devices. By
 default 'auto' is assumed as device_id which
-automatically try to do the right thing, sending
+automatically tries to do the right thing, sending
 keyboard events to a keyboard device and mouse events to
 a mouse device. Other possible values are 'mouse' and
 \&'keyboard'. A device_id of '0' refers to the first
@@ -1200,7 +1200,7 @@ not give you a mouse or keyboard device, these are just
 symbolic names for the devices into which xboxdrv will
 sort events that look like a mouse or keyboard
 event. The final determination of which device gets
-handled as what will be done by the Kernel or Xorg
+handled as what will be done by the kernel or Xorg
 depending on what events a device provides. 
 
 An example configuration making use of device_id would look like this:
@@ -1240,7 +1240,7 @@ pressed it will send a JS_2 event instead. This allows
 you to multiply the number of available buttons on the
 controller.
 
-See the section KEYBOARD EMULATION below on how to
+See section KEYBOARD EMULATION below on how to
 resolve issues with Xorg not detecting the virtual
 keyboard that xboxdrv creates.
 
@@ -1275,7 +1275,7 @@ NAME       = STRING ;\*(T>
 .fi
 
 Similar to \*(T<\fB\-\-ui\-buttonmap\fR\*(T> this option
-allows you to change the event code that is send to the
+allows you to change the event code that is sent to the
 kernel for axes. The events that are available are the
 same as for \*(T<\fB\-\-ui\-buttonmap\fR\*(T>.
 
@@ -1284,33 +1284,33 @@ same as for \*(T<\fB\-\-ui\-buttonmap\fR\*(T>.
 .fi
 
 \fIVALUE\fR gives
-the maximum value of the event, the actual value that gets send
+the maximum value of the event, the actual value that gets sent
 is \fIVALUE\fR * axis_state.
 (default: 10)
 
 \fIREPEAT\fR
-gives the number of milisecond to pass before the event
+gives the number of milliseconds to pass before the event
 is fired again (default: 5).
 
 The value of -1 has a special meaning, it will result in
 the REL event being fired as soon as possible (i.e.
-every \fItimeout\fR miliseconds).
-This is the recomment way for handling mouse emulation,
-as it will keep REL events syncronized and thus avoid
-jaggies in the movement, that will result from manually
+every \fItimeout\fR milliseconds).
+This is the recommended way for handling mouse emulation
+as it will keep REL events synchronized and thus avoid
+jaggies in the movement that will result from manually
 specifying a timeout.
 
 .nf
 \*(T<$ xboxdrv \-\-ui\-axismap X1=KEY_UP:KEY_DOWN:THRESHOLD\*(T>
 .fi
 
-\fIKEY_UP\fR gives the keycode to be send when the axis is moved up
+\fIKEY_UP\fR gives the keycode to be sent when the axis is moved up
 
-\fIKEY_DOWN\fR gives the keycode to be send when the axis is moved down
+\fIKEY_DOWN\fR gives the keycode to be sent when the axis is moved down
 
 \fITHRESHOLD\fR gives the threshold that triggers the sending of an event
 
-Just like \*(T<\fB\-\-ui\-buttonmap\fR\*(T>, you can
+Just like with \*(T<\fB\-\-ui\-buttonmap\fR\*(T>, you can
 also use shift keys in place of the XBOXAXIS:
 
 .nf
@@ -1322,17 +1322,17 @@ events when the LB button is held down.
 
 For information on how to use axis filters, see [Axis Filter].
 .SH "INPUT EVENT HANDLER"
-Input event handler decide what comes out of the virtual input
-devices that xboxdrv creates. They for example decide that when
-button A is pressed on a gamepad, that a virtual keyboard will
+Input event handler decides what comes out of the virtual input
+devices that xboxdrv creates. They, for example, decide that when
+button A is pressed on a gamepad, a virtual keyboard will
 emit a press of the space key.
 .PP
-Furthermore input event handler can also perform some basic
+Furthermore, input event handler can perform some basic
 transformation of the input signals, thus a joystick can be used
 to send WASD keys.
 .SS "BUTTON EVENT HANDLER"
 A button event handler decides what happens when a button is
-pressed, it needs to be specified with
+pressed. It needs to be specified with
 the \*(T<\fB\-\-ui\-buttonmap\fR\*(T> option. The example below
 shows the simplest use case:
 .PP
@@ -1345,14 +1345,14 @@ handler, while \*(T<\fBKEY_A\fR\*(T> is an argument for the
 event handler. What kind of arguments an event handler allows
 depends on the event handler.
 .PP
-There is also a shorthand form of specifing event handlers by
+There is also a shorthand form of specifying event handlers by
 just writing:
 .PP
 .nf
 \*(T<$ xboxdrv \-\-ui\-buttonmap A=KEY_A\*(T>
 .fi
 .PP
-Here no handler is specified explicitly, if that is the case,
+Here no handler is specified explicitly. If that is the case,
 the appropriate handler will be guessed based on the event
 type. \*(T<EV_KEY\*(T> events will be handled by
 the \*(T<\fBkey\fR\*(T> handler, \*(T<EV_REL\*(T> by
@@ -1364,14 +1364,14 @@ The \*(T<\fBkey\fR\*(T> handler is the most basic one,
 it maps a button directly to a virtual key or another
 button.
 
-If additional arguments are supplied the button will be
+If additional arguments are supplied, the button will be
 able to send out two different events. The first event
-specified will be send when the button is clicked
-normally, while the second event will be send in case
-the button is hold down for the time specified
+specified will be sent when the button is pressed
+normally, while the second event will be sent in case
+the button is held down for the time specified
 in \fIHOLD_THRESHOLD_MSEC\fR.
 
-An example for the hold button would look like:
+An example for the hold button feature looks like:
 
 .nf
 \*(T<xboxdrv \e
@@ -1380,9 +1380,9 @@ An example for the hold button would look like:
 
 This will send JS_0 events when the button is pressed
 and switch to JS_1 events when the button was hold for
-500 miliseconds.
+500 milliseconds.
 
-The hold button feature is useful to effectly double the
+The hold button feature is useful to effectively double the
 number of available buttons, thus the dpad can for
 example be used to send out eight different button
 events instead of just four, which is enough to handle
@@ -1392,11 +1392,11 @@ weapons in most FPS games.
 not yet implemented
 .TP 
 \*(T<\fBrel\fR\*(T>:\fIREL_EVENT\fR:\fIVALUE\fR:\fIREPEAT\fR
-The rel handler will send out a REL event whenever the
+The \*(T<\fBrel\fR\*(T> handler will send out a REL event whenever the
 button is pressed. \fIVALUE\fR
-gives the value of the event that will be send,
+gives the value of the event that will be sent,
 while \fIREPEAT\fR gives the number
-of miliseconds till the event will be send again.
+of milliseconds till the event will be sent again.
 
 A typical use for REL events is emulation of the scroll
 wheel of a mouse, an example configuration would be:
@@ -1410,11 +1410,11 @@ Here Y will scroll up and A will scroll down.
 .TP 
 \*(T<\fBcycle\-key\fR\*(T>:\fIKEY_EVENT\fR:...
 The cycle-key handler will switch
-the \fIKEY_EVENT\fR that gets send
+the \fIKEY_EVENT\fR that gets sent
 with each button press. This is useful in situations
 where a range of buttons should be mapped to a single
 key. For example a FPS might have weapons mapped from 1
-to 6, but only a single key on the gamepad is free, thus
+to 6 while only a single key on the gamepad is free, thus
 one could write:
 
 .nf
@@ -1442,8 +1442,8 @@ weapon keys forward, while B is used to toggle the keys backwards:
 The \*(T<\fBcycle\-key\-ref\fR\*(T> handler will access
 and reuse the named cycle keysequence given
 by \fINAME\fR.
-If \fIDIRECTION\fR can either be
-\&'forward' or 'backward', if no direction is supplied it
+\fIDIRECTION\fR can either be
+\&'forward' or 'backward', if no direction is supplied, it
 will default to 'backward'.
 
 See \*(T<\fBcycle\-key\-named\fR\*(T> for a full example.
@@ -1457,7 +1457,7 @@ around when reaching the beginning or end of the
 sequence.
 
 This behaviour is useful in flight simulations or other
-games where thrusters might be controllered by numeric
+games where thrusters might be controlled by numeric
 keys and it wouldn't make much sense to jump from zero
 to full thrust in one go.
 
@@ -1497,7 +1497,7 @@ send KEY_LEFTSHIFT 0\*(T>
 
 All abs, rel and key events can be send from a macro file.
 .SS "AXIS EVENT HANDLER"
-Axis event handler decide what happens when an axis is moved.
+Axis event handler decides what happens when an axis is moved.
 Like button event handler they come in different forms and
 like button event handler they provide a shortcut
 form. \*(T<EV_KEY\*(T> events will be handled by
@@ -1507,7 +1507,7 @@ by the \*(T<\fBabs\fR\*(T> handler.
 .TP 
 \*(T<\fBabs\fR\*(T>:\fIABS_EVENT\fR
 The \*(T<\fBabs\fR\*(T> handler is the simplest of them
-all, it will simply send out the value it gets as input
+all, it will simply send out the input value it gets
 as the given \fIABS_EVENT\fR event
 to the kernel. Thus a basic configuration to make the
 left stick behave as joystick would look like this:
@@ -1518,9 +1518,9 @@ left stick behave as joystick would look like this:
 .fi
 .TP 
 \*(T<\fBkey\fR\*(T>:\fIKEY_UP\fR:\fIKEY_DOWN\fR:\fITHRESHOLD\fR
-\fIKEY_UP\fR gives the keycode to be send when the axis is moved up
+\fIKEY_UP\fR gives the keycode to be sent when the axis is moved up
 
-\fIKEY_DOWN\fR gives the keycode to be send when the axis is moved down
+\fIKEY_DOWN\fR gives the keycode to be sent when the axis is moved down
 
 \fITHRESHOLD\fR gives the threshold that triggers the sending of an event
 
@@ -1536,18 +1536,18 @@ events when the LB button is held down.
 .TP 
 \*(T<\fBrel\fR\*(T>:\fIREL_EVENT\fR:\fIVALUE\fR:\fIREPEAT\fR
 \fIVALUE\fR gives
-the maximum value of the event, the actual value that gets send
+the maximum value of the event, the actual value that gets sent
 is \fIVALUE\fR * axis_state.
 (default: 10)
 
 \fIREPEAT\fR
-gives the number of milisecond to pass before the event
+gives the number of millisecond to pass before the event
 is fired again (default: 5).
 
 The value of -1 has a special meaning, it will result in
 the REL event being fired as soon as possible (i.e.
-every \fItimeout\fR miliseconds).
-This is the recomment way for handling mouse emulation,
+every \fItimeout\fR milliseconds).
+This is the recommended way for handling mouse emulation,
 as it will keep REL events syncronized and thus avoid
 jaggies in the movement, that will result from manually
 specifying a timeout.
@@ -1566,18 +1566,18 @@ emulating the scroll wheel of a mouse.
 the axis has moved, instead it is constant, instead the
 time given in \fIREPEAT\fR is
 scaled according to the axis movement. Thus the further
-the stick is moved, the more events will be send.
+the stick is moved, the more events will be sent.
 
 The need for both \*(T<\fBrel\-repeat\fR\*(T>
 and \*(T<\fBrel\fR\*(T> arises from the fact that Xorg
 converts scroll wheel movement to button presses before
 they are handed to an application, thus an application
 never properly sees the changes
-in \fIVALUE\fR, by
+in \fIVALUE\fR. By
 scaling \fIREPEAT\fR instead that
 problem is worked around.
 .SH "INPUT FILTER"
-Input filter allow to manipulate the events that come from the
+Input filter allows to manipulate the events that come from the
 controller. They can be used
 on \*(T<\fB\-\-buttonmap\fR\*(T>, \*(T<\fB\-\-axismap\fR\*(T>, \*(T<\fB\-\-ui\-buttonmap\fR\*(T>
 and \*(T<\fB\-\-ui\-axismap\fR\*(T>. The difference between the
@@ -1588,7 +1588,7 @@ controller events.
 .TP 
 \*(T<\fBtog\fR\*(T>, \*(T<\fBtoggle\fR\*(T>
 The toggle filter will turn the button into a toggle
-button, clicking the button will set it to pressed state
+button, pressing the button will set it to pressed state
 and pressing it again will unpress it. Useful for games
 where you might want to permanently run or duck without
 holding the button pressed.
@@ -1599,47 +1599,47 @@ when it is not pressed and in unpressed state when it is
 pressed.
 .TP 
 \*(T<\fBauto\fR\*(T>, \*(T<\fBautofire\fR\*(T>:\fIRATE\fR:\fIDELAY\fR
-The autofire filter allows to repeatatly send button
+The autofire filter allows to repeatedly send button
 press events when the button is held down. It takes two
 optional parameters:
 
 \fIRATE\fR is the number of
-miliseconds between button press events.
+milliseconds between button press events.
 
 \fIDELAY\fR the amount of
-miliseconds till the autofire will start, before that
+milliseconds till the autofire will start, before that
 delay the button will act as normal.
 .TP 
 \*(T<\fBclick\-press\fR\*(T>
 The \*(T<\fBclick\-press\fR\*(T> filter will transmit a single button
-click when the button is pressed.
+press when the button is pressed.
 .TP 
 \*(T<\fBclick\-release\fR\*(T>
 The \*(T<\fBclick\-release\fR\*(T> filter will transmit a single button
-click when the button is released.
+press when the button is released.
 .TP 
 \*(T<\fBclick\-both\fR\*(T>
 The \*(T<\fBclick\-both\fR\*(T> filter will transmit a
-single button click when the button is pressed and
+single button press when the button is pressed and
 another one when it is released.
 .TP 
 \*(T<\fBconst\fR\*(T>:\fIVALUE\fR
 The const filter will ignore the input signal and send a
-constant value to the output. This can be used for
-example in combination with multiple configurations to
+constant value to the output. This can be used, for
+example, in combination with multiple configurations to
 signal a game or another application which configuration
 is currently active.
 .TP 
 \*(T<\fBdelay\fR\*(T>:\fITIME\fR
-A button has to be held down for TIME miliseconds before
-it will emit an event, press events shorter then that will
+A button has to be held down for TIME milliseconds before
+it will emit an event, press events shorter than that will
 be ignored.
 .TP 
 \*(T<\fBlog\fR\*(T>:\fISTRING\fR
 The log filter will output everything to stdout that
-goes through it to, this is useful for debugging the
+goes through it, this is useful for debugging the
 filter. A \fISTRING\fR can be
-provided as parameter that will be outputed before the
+provided as parameter that will be outputted before the
 event.
 .SS "AXIS FILTER"
 .TP 
@@ -1687,9 +1687,9 @@ is currently active.
 .TP 
 \*(T<\fBlog\fR\*(T>:\fISTRING\fR
 The log filter will output everything to stdout that
-goes through it to, this is useful for debugging the
+goes through it, this is useful for debugging the
 filter. A \fISTRING\fR can be
-provided as parameter that will be outputed before the
+provided as parameter that will be outputted before the
 event.
 .SS MODIFIER
 While button and axis filter only apply to a single axis or
@@ -1738,13 +1738,13 @@ real events and not be confused by auto-fire or similar
 modifications.
 .SH "RUNNING XBOXDRV"
 .SS "USING A SINGLE CONTROLLER"
-Plug in your Xbox360 gamepad and then unload the xpad driver via:
+Plug in your Xbox360 gamepad and then unload the xpad driver with:
 .PP
 .nf
 \*(T<$ rmmod xpad\*(T>
 .fi
 .PP
-If you want to permanently unload it add the following line to
+If you want to permanently unload it, add the following line to
 \*(T<\fI/etc/modprobe.d/blacklist.conf\fR\*(T>:
 .PP
 .nf
@@ -1752,8 +1752,8 @@ If you want to permanently unload it add the following line to
 .fi
 .PP
 Next you have to load the uinput kernel module which allows
-userspace programms to create virtual input devices and the
-joydev module handles the \*(T<\fI/dev/input/jsX\fR\*(T>
+userspace programs to create virtual input devices and the
+joydev module which handles the \*(T<\fI/dev/input/jsX\fR\*(T>
 devices:
 .PP
 .nf
@@ -1765,7 +1765,7 @@ You also have to make sure that you have access rights to
 /dev/input/uinput, either add yourself to the appropriate group,
 adjust the permissions or run xboxdrv as root.
 .PP
-Once ensured that xpad is out of the way and everything is in place
+Once ensured that xpad is out of the way and everything is in place,
 start the userspace driver with:
 .PP
 .nf
@@ -1780,24 +1780,24 @@ should often be enough) start the driver as root via:
 .fi
 .PP
 This will create /dev/input/js0 and allow you to access the
-gamepad from any game. To exit the driver press Ctrl-c.
+gamepad from any game. To exit the driver, press Ctrl-C.
 .PP
-By default xboxdrv will echo all controller events to the
+By default, xboxdrv will echo all controller events to the
 console, this makes it easy to see if things are properly
 working, but will eat a lot of CPU, thus it is strongly
-recomment to disabled that output with
+recommended to disable that output with
 the \*(T<\fB\-\-silent\fR\*(T> option.
 .PP
 The trigger buttons are handled by xboxdrv normally as axis,
 giving you analog feedback, while this reproduces the Xbox360
 controller the most accurately, it will confuse many and only
 be useful in a few, racing games mainly. So in the majority of
-cases it is recomment to change the triggers to regular buttons via:
+cases it is recommended to change the triggers to regular buttons via:
 .PP
 .nf
 \*(T<$ xboxdrv \-\-trigger\-as\-button\*(T>
 .fi
-.SS "USING MULTIPLE CONTROLLER"
+.SS "USING MULTIPLE CONTROLLERS"
 If you want to use multiple wired controllers you need to start
 multiple instances of the xboxdrv driver and append the -i
 argument to select the appropriate controller like this:
@@ -1806,7 +1806,7 @@ argument to select the appropriate controller like this:
 \*(T<$ xboxdrv \-i 1\*(T>
 .fi
 .PP
-If you have multiple wireless controller you need to start
+If you have multiple wireless controllers you need to start
 multiple instances of the xboxdrv driver and append
 the \*(T<\fB\-\-wid\fR\*(T> option like this:
 .PP
@@ -1817,7 +1817,7 @@ the \*(T<\fB\-\-wid\fR\*(T> option like this:
 You have to sync the wireless controller as usual.
 .PP
 To see a list of all the controllers that xboxdrv detects
-being connected to your system use:
+being connected to your system, use:
 .PP
 .nf
 \*(T<$ xboxdrv \-\-list\-controller\*(T>
@@ -1867,7 +1867,7 @@ it you can write its pid via the \*(T<\fB\-\-pid\-file\fR\*(T>:
 \*(T<$ sudo xboxdrv \-\-daemon \-\-detach \-\-pid\-file /var/run/xboxdrv.pid\*(T>
 .fi
 .SH "XBOXDRV DAEMON DBUS INTERFACE"
-When Xboxdrv is run as daemon it will export some API functions
+When xboxdrv is run as daemon it will export some API functions
 via D-Bus, thus allowing to make configuration changes at
 runtime. The D-Bus interface can be accessed either by the
 numerous language bindings provided or via the generic command line tool
@@ -1923,7 +1923,7 @@ understanding what is wrong in a given setup. Testing the
 configuration in a game is most often not helpful, since you won't see
 the true cause beyond endless layers of abstraction between you and
 the actual events. Luckily there are a few tools you can use to test,
-all of these are command line based and it is recomment that you get
+all of these are command line based and it is recommended that you get
 familar with them when you want to do any more complex configuration.
 .SS EVTEST
 evtest lets you read raw input events from \*(T<\fI/dev/input/eventX\fR\*(T>. The
@@ -1932,16 +1932,15 @@ joystick devices are derived from the event device, so if you want to
 fix some issue on the joystick device, you have to fix the event
 device.
 .PP
-evtest is available in the tools/ directory or as part of your
-distribution in the package \*(T<\fIevtest\fR\*(T>. your
-distribution.
+evtest is available in the \*(T<\fItools/X\fR\*(T> directory or as part of your
+distribution in the package \*(T<\fIevtest\fR\*(T>.
 .SS JSTEST
 jstest lets you read the output out of a joystick event device (/dev/input/js0).
 .PP
 jstest is available in the tools/ directory or as part of your
-distribution \*(T<\fIjoystick\fR\*(T>.
+distribution (included inside \*(T<\fIjoystick\fR\*(T> package in most popular distributions). 
 .SS SDL-JSTEST
-sdl-jstest lets you see events as games using SDL see them. This is
+sdl-jstest lets you see events as games using SDL to see them. This is
 very important when you want to set and test the SDL_LINUX_JOYSTICK
 environment variables.
 .PP
@@ -1957,13 +1956,13 @@ xev lets you see the events that Xorg sees. Note however that you
 might not see all events, since some will be grapped by your Window
 manager before they reach xev, this is normal.
 .PP
-xev is part of every Linux distribution, on Ubuntu its available via:
+xev is part of every Linux distribution, on Ubuntu it's available via:
 .PP
 .nf
 \*(T<$ apt\-get install x11\-utils\*(T>
 .fi
 .SS "JSCALC AND JSCALIBRATOR"
-Both of these tools lets you calibrate your gamepad, however
+Both of these tools let you calibrate your gamepad, however
 with pretty much all current gamepads this is no longer
 needed and actually harmful as it might overwrite a perfectly
 good working configuration with a broken one (unplugging the
@@ -1971,7 +1970,7 @@ gamepad or a reboot will fix that). So avoid them unless you
 clearly understand the issues of using them.
 .PP
 If your gamepad produces incorrect data and you do want to
-calibrate it you might want to check out the
+calibrate it, you might want to check out the
 option \*(T<\fB\-\-calibration\fR\*(T>, which lets you tweak
 the way xboxdrv interprets your gamepad data.
 .SS MOUSE
@@ -1987,7 +1986,7 @@ directory of the xboxdrv source tree or
 in \*(T<\fI/usr/share/doc/xboxdrv/examples/\fR\*(T>.
 .SS "TURNING TRIGGERS INTO BUTTONS"
 By default xboxdrv will handle the trigger as analog axis, not
-buttons, while this is beneficial for racing games, it will
+button, while this is beneficial for racing games, it will
 confuse many other games, thus xboxdrv provides an easy way to
 change the handling into buttons via
 the \*(T<\fB\-\-trigger\-as\-button\fR\*(T> option:
@@ -2016,7 +2015,7 @@ you have to use axis filter:
 The following configuration will cause xboxdrv to emulate a
 keyboard, which can be useful for games that are played with
 keyboard, like Flash games or games that don't support a
-joystick. Since different games use different keyboard keys
+joystick. Since different games use different keyboard keys,
 you might have to adjust the keybindings to fit the game:
 .PP
 .nf
@@ -2027,7 +2026,7 @@ you might have to adjust the keybindings to fit the game:
 .fi
 .SS "FIGHTING GAMES:"
 In this configuration the left and right trigger get turned
-into digital buttons. All axis except the dpad are ignored. RB
+into digital buttons. All axes except the dpad are ignored. RB
 and RT are mapped to act as if buttons 1,2 and 3 are pressed
 simultaniously which is useful for some special attacks.
 Instead of using the native button names, the 1,2,3,...
@@ -2057,14 +2056,14 @@ Start xboxdrv with:
   \-\-relative\-axis y2=64000 \-\-axismap \-y2=x2,x2=y2\*(T>
 .fi
 .PP
-Your right analog stick will act as trottle control, the
+Your right analog stick will act as throttle control, the
 trigger as rudder. Using \*(T<\fB\-\-modifier\fR\*(T> to
 install a four-way restrictor might also be worth a
-consideration to not accidently touch the throttle when the
+consideration so as to not accidentally touch the throttle when the
 rudder is moved.
 .SS "USING MOUSE EMULATION AND JOYSTICK AT THE SAME TIME"
 To use mouse emulation and joystick at the same time you have
-to register two configuration with xboxdrv, this works via:
+to register two configurations with xboxdrv, this works via:
 .PP
 .nf
 \*(T<$ xboxdrv \-\-next\-config \-\-mouse\*(T>
@@ -2075,11 +2074,11 @@ configuration and all configuration options on the right side
 of it will go there, while everything on the left side of it
 will go into the first configuration. Toggling between the
 configurations works with the guide button, you can have as
-many configuratios as you want.
-.SS "MAPPING EVERY BUTTON MULTIPLE"
+many configurations as you want.
+.SS "MAPPING MULTIPLE EVENTS TO EVERY BUTTON"
 Some games might require more buttons then your gamepad has,
-in those situation it can be useful to map a button twice by
-using shifted buttons:
+in those situations it can be useful to map a button twice by
+using shift buttons:
 .PP
 .nf
 \*(T<$ xboxdrv \e
@@ -2090,13 +2089,13 @@ using shifted buttons:
   \-\-ui\-buttonmap rb+a=JS_8,rb+b=JS_9,rb+x=JS_10,rb+y=JS_11
 \*(T>.fi
 .PP
-Here all face buttons are get mapped three times, once when
+Here all face buttons get mapped three times, once when
 pressed normally, once when pressed while LB is held down and
 once when RB is held down, thus given you for the six buttons
 12 virtual ones.
 .SS SAUERBRATEN
-First analogstick gets mapped te cursor keys, second
-analogstick gets mapped to mouse. Note: This is just an
+First analog stick gets mapped to cursor keys, second
+analog stick gets mapped to mouse. Note: This is just an
 incomplete example, not a perfectly playable configuration,
 you have to do tweaking yourself.
 .PP
@@ -2123,7 +2122,7 @@ configuration, you have to do tweaking yourself.
   \-s \-\-deadzone 6000 \-\-dpad\-as\-button \-\-trigger\-as\-button\*(T>
 .fi
 .SH "WRITING START-UP SCRIPTS FOR GAMES"
-When you want full game specific configurability and automatic
+When you want full game-specific configurability and automatic
 launching of xboxdrv, it is easiest to write little startup
 scripts for your games that will launch xboxdrv, launch your
 game and then when the game is finished tear down xboxdrv:
@@ -2141,15 +2140,15 @@ exec xboxdrv \e
 .PP
 Here \*(T<\fIyour_favorite_game\fR\*(T> is the executable
 of your game and is passed to xboxdrv as last argument. This
-will cause xboxdrv to start the game and keep running as long as
-the game is running, when the game is done, xboxdrv will quit
+will cause xboxdrv to start the game and keep running for as long as
+the game is running. When the game is done, xboxdrv will quit
 automatically.
 .PP
 If you want to pass parameters to the game you have to add
 a \*(T<\fB\-\-\fR\*(T> separator, as otherwise your options to
 the game would be eaten up by xboxdrv.
 .SH "SDL NOTES"
-To let SDL know which axis act as a hat and which act as normal axis
+To let SDL know which axes act as a hat and which act as normal axis
 you have to set an environment variable:
 .PP
 .nf
@@ -2158,7 +2157,7 @@ $ SDL_LINUX_JOYSTICK="'Xbox Gamepad (userspace driver)' 6 1 0"
 $ export SDL_LINUX_JOYSTICK\*(T>
 .fi
 .PP
-You might also need in addition use this (depends on the way SDL was compiled):
+You might also need in addition use to this (depends on the way SDL was compiled):
 .PP
 .nf
 \*(T<
@@ -2166,25 +2165,25 @@ $ SDL_JOYSTICK_DEVICE="/dev/input/js0"
 $ export SDL_JOYSTICK_DEVICE\*(T>
 .fi
 .PP
-This will let the DPad act as Hat in SDL based application. For
+This will let the DPad act as hat in SDL-based application. For
 many games the driver will work without this, but especially in
-Dosbox this variable is very important.
+DOSBox this variable is very important.
 .PP
-If you use options in xboxdrv that change the number of axis you
+If you use options in xboxdrv that change the number of axes you
 have to adjust the variable accordingly, see:
 .TP 0.2i
 \(bu
 \(laftp://ptah.lnf.kth.se/pub/misc/sdl-env-vars\(ra
 .TP 
 SDL_LINUX_JOYSTICK
-Special joystick configuration string for linux. The format is
+Special joystick configuration string for Linux. The format is
 \*(T<\fB"name numaxes numhats numballs"\fR\*(T>
 where name is the name string of the joystick (possibly in single
 quotes), and the rest are the number of axes, hats and balls
 respectively.
 .TP 
 SDL_JOYSTICK_DEVICE
-Joystick device to use in the linux joystick driver, in addition to the usual: \*(T<\fI/dev/js*\fR\*(T>, \*(T<\fI/dev/input/event*\fR\*(T>, \*(T<\fI/dev/input/js*\fR\*(T>
+Joystick device to use in the Linux joystick driver, in addition to the usual: \*(T<\fI/dev/js*\fR\*(T>, \*(T<\fI/dev/input/event*\fR\*(T>, \*(T<\fI/dev/input/js*\fR\*(T>
 .SH TROUBLESHOOTING
 .SS "\(dqNO XBOX OR XBOX360 CONTROLLER FOUND\(dq"
 This means that either your controller isn't plugged in or is
@@ -2207,7 +2206,7 @@ to <\*(T<grumbel@gmail.com\*(T>>, if not, contact me too, I
 might be able to provide additional help.
 .PP
 As an alternative you can also use the --device and --type option to
-enforce a USB device as well as a controller type an bypass any auto
+enforce a USB device as well as a controller type to bypass any auto
 detection.
 .SS "\(dqUNKNOWN DATA: BYTES: 3 DATA: ...\(dq"
 This means that your controller is sending data that isn't understood
@@ -2216,7 +2215,7 @@ the Xbox360 controller seems to send out useless data every now and
 then. If your controller does not work and you get plenty of those
 lines when you move the sticks or press buttons it means that your
 controller talks an un-understood protocol and some reverse
-enginiering is required. Contact <\*(T<grumbel@gmail.com\*(T>> and include the output
+engineering is required. Contact <\*(T<grumbel@gmail.com\*(T>> and include the output
 of:
 .PP
 .nf
@@ -2236,7 +2235,7 @@ itself works with:
 \*(T<$ xboxdrv \-\-no\-uinput \-v\*(T>
 .fi
 .SS "THE WIRELESS CONTROLLER DOESN'T WORK"
-You have to sync the controller befor it can be used, restart of the
+You have to sync the controller before it can be used, restart of the
 driver isn't needed and the driver should let you now when it recieves
 a connection after you sync the controller.
 .SS "KEYBOARD EMULATION"
@@ -2244,7 +2243,7 @@ When you try to let xboxdrv send a keyboard events
 via \*(T<\fB\-\-ui\-buttonmap\fR\*(T>
 or \*(T<\fB\-\-ui\-axismap\fR\*(T> Xorg must register the device
 as keyboard device to work properly. This seems to work
-automatically when you bind more then two keyboard keys, if you
+automatically when you bind more than two keyboard keys, if you
 bind less you need to create the
 file \*(T<\fI/etc/hal/fdi/preprobe/xboxdrv.fdi\fR\*(T>
 containing:
@@ -2278,7 +2277,7 @@ device js0 and replace it with a symbolic link js1 via:
 .PP
 This workaround will only last till the next reboot, since the device
 names are dynamically created, but for the time being there doesn't
-seem to any other way to easily work around this issue. 
+seem to be any other way to easily work around this issue. 
 .PP
 In newer kernels this issue is fixed.
 .SS "UINPUT ISSUES"
@@ -2300,18 +2299,18 @@ This means games will not display the proper button labels, but
 just numbers (i.e. 'Btn1' instead of 'A' for example). Aside
 from that it should work fine.
 .PP
-XInput support (the Microsoft DirectInput replacment, not the
+XInput support (the Microsoft DirectInput replacement, not the
 Xorg xinput) is as of January 2011 not implemented in Wine, so
 games that require XInput and don't have an DirectInput fallback
 will not work with a Xbox360 controller, unofficial patches
 however do exist.
 .SH "XORG ISSUES"
 If you start xboxdrv and instead of having a fully working
-joystick, you end up controlling the mouse that might be due to
+joystick you end up controlling the mouse, that might be due to
 recent changes in Xorg and its device hotplug handling. There
 are four workarounds, the one that involves
 editing \*(T<\fI/etc/hal/fdi/policy/preferences.fdi\fR\*(T>
-is the recommont one.
+is the recommended one.
 .SS "TEMPORARY WORKAROUND USING HAL-DEVICE"
 Get the device id from hal:
 .PP
@@ -2333,7 +2332,7 @@ $ xinput set\-int\-prop $DEVICEID 'Device Enabled' 32 0\*(T>
 .fi
 .SS "PERMANENT WORKAROUND USING .FDI FILES"
 The former two workarounds are just temporary and have to be redone
-after each start of xboxdrv, the last workaround is a permanent one:
+after each start of xboxdrv, this workaround is a permanent one:
 .PP
 You have to edit:
 .PP
@@ -2349,7 +2348,7 @@ And insert the following lines:
 .fi
 .SS "PERMANENT WORKAROUND BY DISABLING DEVICE AUTO DETECTION"
 A fourth workaround involved disabling the autodetection of Xorg
-completly, you can do that by adding the following lines to
+completely, you can do that by adding the following lines to
 \*(T<\fI/etc/X11/xorg.conf\fR\*(T>:
 .PP
 .nf
@@ -2358,12 +2357,12 @@ completly, you can do that by adding the following lines to
 EndSection\*(T>
 .fi
 .PP
-Note that without auto detection you will have to manually configure
+Note that without autodetection you will have to manually configure
 all your mice and keyboards or your Xorg Server won't start up
 properly. So unless you are already familiar with editing Xorg you
 better avoid this workaround. Workaround 3) has basically the same
-effect, except that auto detection only gets disabled for the single
-device it is causing problems.
+effect, except that autodetection only gets disabled for the single
+device it is causing problems to.
 .SH "FORCE FEEDBACK PROGRAMMING"
 For documentation on the FF interface see:
 .TP 0.2i
@@ -2386,7 +2385,7 @@ information can be found at:
 interface.
 .PP
 Force feedback is disabed by default since it causes trouble in
-certain application. "Tomb Raider: Legend" for example when run
+certain applications. "Tomb Raider: Legend" for example when run
 in Wine crashes at startup when rumble is enabled, while it
 works perfectly normal when rumble is disabled.
 .SH BUGS
@@ -2396,20 +2395,20 @@ when Foobar is mapped to multiple keycodes in the keymap.
 .PP
 Workaround: Use \fBKEY_\fR instead or cleanup your keymap
 .PP
-Newer versions of Xorg will also do perform some auto
+Newer versions of Xorg will also perform some auto
 configuration that might lead to your keymap being switched
 whenever a new keyboard is detected, in cases of custom
 Xmodmaps this might confuse xboxdrv and make the XK_ style
 names unusable. No workaround for that is known right now.
 .SS "NON-INTERRUPTABLE PROCESSES DUE TO FORCE FEEDBACK"
-Force feedback support is brittle, if you Ctrl-c the driver in the
+Force feedback support is brittle, if you Ctrl-C the driver in the
 wrong moment you will end up with a dead uninterruptable process and
 basically have to reboot. This looks like it might be a kernel issue
-and not a xboxdrv one.
+and not an xboxdrv one.
 .PP
 Workaround: Kill the app that uses xboxdrv before xboxdrv itself.
 .SS "QUESTIONS, BUG REPORTS AND FEATURE REQUESTS"
-Bug reports and feature request can be report to the xboxdrv issue tracker at:
+Bug reports and feature requests can be reported to the xboxdrv issue tracker at:
 .PP
 .URL https://github.com/Grumbel/xboxdrv/issues/new ""
 .PP

--- a/doc/xboxdrv.1
+++ b/doc/xboxdrv.1
@@ -1969,7 +1969,7 @@ good working configuration with a broken one (unplugging the
 gamepad or a reboot will fix that). So avoid them unless you
 clearly understand the issues of using them.
 .PP
-If your gamepad produces incorrect data and you do want to
+If your gamepad produces incorrect data and you want to
 calibrate it, you might want to check out the
 option \*(T<\fB\-\-calibration\fR\*(T>, which lets you tweak
 the way xboxdrv interprets your gamepad data.
@@ -2284,7 +2284,7 @@ In newer kernels this issue is fixed.
 On Ubuntu 9.04 the permissions of the uinput device have
 changed to 0640, meaning only root has access to the device.
 To change this back so that users in the group root have
-access the device and in turn can run xboxdrv without sudo you
+access to the device and in turn can run xboxdrv without sudo you
 have to create a file
 called \*(T<\fI/etc/udev/rules.d/55\-permissions\-uinput.rules\fR\*(T>
 with the content:
@@ -2347,7 +2347,7 @@ And insert the following lines:
 </match>\*(T>
 .fi
 .SS "PERMANENT WORKAROUND BY DISABLING DEVICE AUTO DETECTION"
-A fourth workaround involved disabling the autodetection of Xorg
+A fourth workaround involves disabling the autodetection of Xorg
 completely, you can do that by adding the following lines to
 \*(T<\fI/etc/X11/xorg.conf\fR\*(T>:
 .PP

--- a/doc/xboxdrv.xml
+++ b/doc/xboxdrv.xml
@@ -1883,7 +1883,7 @@ NAME       = STRING ;]]></programlisting>
               The value of -1 has a special meaning, it will result in
               the REL event being fired as soon as possible (i.e.
               every <replaceable>timeout</replaceable> miliseconds).
-              This is the recomment way for handling mouse emulation,
+              This is the recommended way for handling mouse emulation,
               as it will keep REL events syncronized and thus avoid
               jaggies in the movement, that will result from manually
               specifying a timeout.
@@ -2223,7 +2223,7 @@ send KEY_LEFTSHIFT 0]]></programlisting>
               The value of -1 has a special meaning, it will result in
               the REL event being fired as soon as possible (i.e.
               every <replaceable>timeout</replaceable> miliseconds).
-              This is the recomment way for handling mouse emulation,
+              This is the recommended way for handling mouse emulation,
               as it will keep REL events syncronized and thus avoid
               jaggies in the movement, that will result from manually
               specifying a timeout.
@@ -2635,7 +2635,7 @@ $ modprobe joydev]]></programlisting>
         By default xboxdrv will echo all controller events to the
         console, this makes it easy to see if things are properly
         working, but will eat a lot of CPU, thus it is strongly
-        recomment to disabled that output with
+        recommended to disabled that output with
         the <option>--silent</option> option.
       </para>
 
@@ -2644,7 +2644,7 @@ $ modprobe joydev]]></programlisting>
         giving you analog feedback, while this reproduces the Xbox360
         controller the most accurately, it will confuse many and only
         be useful in a few, racing games mainly. So in the majority of
-        cases it is recomment to change the triggers to regular buttons via:
+        cases it is recommended to change the triggers to regular buttons via:
       </para>
       <programlisting>$ xboxdrv --trigger-as-button</programlisting>
     </refsect2>
@@ -2783,7 +2783,7 @@ dbus-send --session --type=method_call --print-reply \
       configuration in a game is most often not helpful, since you won't see
       the true cause beyond endless layers of abstraction between you and
       the actual events. Luckily there are a few tools you can use to test,
-      all of these are command line based and it is recomment that you get
+      all of these are command line based and it is recommended that you get
       familar with them when you want to do any more complex configuration.
     </para>
 

--- a/examples/evdev.xboxdrv
+++ b/examples/evdev.xboxdrv
@@ -16,7 +16,7 @@
 # joystick.
 
 [xboxdrv]
-# Using the 'by-id' name is recomment, as it is static, while an
+# Using the 'by-id' name is recommended, as it is static, while an
 # /dev/input/eventX name can change depending on what other USB
 # devices you use.
 evdev = /dev/input/by-id/usb-Microsoft_SideWinder_Precision_2_Joystick-event-joystick

--- a/examples/ps4_usb.xboxdrv
+++ b/examples/ps4_usb.xboxdrv
@@ -2,7 +2,7 @@
 # ========================
 
 [xboxdrv]
-# Using the 'by-id' name is recomment, as it is static, while an
+# Using the 'by-id' name is recommended, as it is static, while an
 # /dev/input/eventX name can change depending on what other USB
 # devices you use.
 evdev = /dev/input/by-id/usb-Sony_Computer_Entertainment_Wireless_Controller-event-joystick

--- a/examples/ps4_usb.xboxdrv
+++ b/examples/ps4_usb.xboxdrv
@@ -1,4 +1,4 @@
-# Playstation 4 Controller
+# PlayStation 4 Controller
 # ========================
 
 [xboxdrv]

--- a/hal/xboxdrv_policy.fdi
+++ b/hal/xboxdrv_policy.fdi
@@ -2,7 +2,7 @@
 
 <deviceinfo version="0.2">
   <device>
-    <match key="input.product" string="Microsoft X-Box 360 pad">     
+    <match key="input.product" string="Microsoft Xbox 360 pad">     
       <remove key="input.x11_driver" />
     </match>
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -352,7 +352,7 @@ Options::set_mimic_xpad()
   extra_devices = false;
   extra_events  = false;
 
-  set_device_name("Microsoft X-Box 360 pad");
+  set_device_name("Microsoft Xbox 360 pad");
   set_device_usbid("045e:028e:110");
   get_controller_options().uinput.mimic_xpad();
 }

--- a/src/xpad_device.cpp
+++ b/src/xpad_device.cpp
@@ -22,20 +22,20 @@
 // automatically catch all third party stuff
 XPadDevice xpad_devices[] = {
   // Evil?! Anymore info we could use to identify the devices?
-  // { GAMEPAD_XBOX,             0x0000, 0x0000, "Generic X-Box pad" },
+  // { GAMEPAD_XBOX,             0x0000, 0x0000, "Generic Xbox pad" },
   // { GAMEPAD_XBOX,             0xffff, 0xffff, "Chinese-made Xbox Controller" },
 
   // These should work
   { GAMEPAD_XBOX,             0x0d2f, 0x0002, "Andamiro Pump It Up pad" },
-  { GAMEPAD_XBOX,             0x045e, 0x0202, "Microsoft X-Box pad v1 (US)" },
-  { GAMEPAD_XBOX,             0x045e, 0x0285, "Microsoft X-Box pad (Japan)" },
+  { GAMEPAD_XBOX,             0x045e, 0x0202, "Microsoft Xbox pad v1 (US)" },
+  { GAMEPAD_XBOX,             0x045e, 0x0285, "Microsoft Xbox pad (Japan)" },
   { GAMEPAD_XBOX,             0x045e, 0x0287, "Microsoft Xbox Controller S" },
-  { GAMEPAD_XBOX,             0x045e, 0x0289, "Microsoft X-Box pad v2 (US)" },
+  { GAMEPAD_XBOX,             0x045e, 0x0289, "Microsoft Xbox pad v2 (US)" },
   // { GAMEPAD_XBOX,          0x045e, 0x0288, "Microsoft Corp. Xbox Controller S Hub" },  memory card slot
   { GAMEPAD_XBOX,             0x046d, 0xca84, "Logitech Xbox Cordless Controller" },
   { GAMEPAD_XBOX,             0x046d, 0xca88, "Logitech Compact Controller for Xbox" },
   { GAMEPAD_XBOX,             0x05fd, 0x1007, "Mad Catz Controller (unverified)" },
-  { GAMEPAD_XBOX,             0x05fd, 0x107a, "InterAct 'PowerPad Pro' X-Box pad (Germany)" },
+  { GAMEPAD_XBOX,             0x05fd, 0x107a, "InterAct 'PowerPad Pro' Xbox pad (Germany)" },
   { GAMEPAD_XBOX,             0x0738, 0x4516, "Mad Catz Control Pad" },
   { GAMEPAD_XBOX,             0x0738, 0x4522, "Mad Catz LumiCON" },
   { GAMEPAD_XBOX,             0x0738, 0x4526, "Mad Catz Control Pad Pro" },
@@ -55,7 +55,7 @@ XPadDevice xpad_devices[] = {
   { GAMEPAD_XBOX,             0x102c, 0xff0c, "Joytech Wireless Advanced Controller" },
   { GAMEPAD_XBOX,             0x044f, 0x0f07, "Thrustmaster, Inc. Controller" },
   { GAMEPAD_XBOX,             0x0e8f, 0x3008, "Generic xbox control (dealextreme)" },
-  { GAMEPAD_XBOX360,          0x045e, 0x028e, "Microsoft X-Box 360 pad" },
+  { GAMEPAD_XBOX360,          0x045e, 0x028e, "Microsoft Xbox 360 pad" },
   //{ GAMEPAD_XBOX360_PLAY_N_CHARGE, 0x045e, 0x028f, "Microsoft Xbox 360 Play&Charge Kit" },
   { GAMEPAD_XBOX360,          0x0738, 0x4716, "Mad Catz Wired Xbox 360 Controller" },
   { GAMEPAD_XBOX360,          0x0738, 0x4726, "Mad Catz Xbox 360 Controller" },


### PR DESCRIPTION
Some corrections might be wrong due to my misunderstanding of grammar rules or meanings of sentences. Also I think the first sentences in --relative-axis and --no-uinput should be reworded and you may want to change dpad spelling to "D-pad" since it seems to be the widely accepted one and capitalization for it is currently somewhat inconsistent anyways.
