### PR TITLE
Added VID / PID for Mad Catz Brawlstick for XBox 360

### DIFF
--- a/src/xpad_device.cpp
+++ b/src/xpad_device.cpp
@@ -126,6 +126,7 @@ XPadDevice xpad_devices[] = {
   { GAMEPAD_XBOX360,          0x24c6, 0x5d04, "Razer Sabertooth" },
   { GAMEPAD_XBOX360,          0x0e6f, 0x011f, "Rock Candy Gamepad Wired Controller" },
   { GAMEPAD_XBOX360,          0x0e6f, 0x021f, "Rock Candy Gamepad for Xbox 360" },
+  { GAMEPAD_XBOX360,          0x1bad, 0xf019, "Mad Catz Brawlstick for Xbox 360" },
 
   { GAMEPAD_XBOX_MAT,         0x0738, 0x4540, "Mad Catz Beat Pad" },
   { GAMEPAD_XBOX_MAT,         0x0738, 0x6040, "Mad Catz Beat Pad Pro" },


### PR DESCRIPTION
This device is an arcade stick that maps dpad to (digital) stick inputs and has 10 digital buttons (LT and RT are buttons not analog).
Tested fine with retropie (allows usage of LT and RT buttons and stopping xbox leds flashing).
