### PR TITLE
Fix "pure virtual function called" crash and related hang

### DIFF
--- a/src/usb_controller.cpp
+++ b/src/usb_controller.cpp
@@ -123,6 +123,13 @@ USBController::get_name() const
   return m_name;
 }
 
+bool
+USBController::parse(uint8_t* data, int len, XboxGenericMsg* msg_out)
+{
+  // dummy method for destructor
+  return false;
+}
+
 void
 USBController::usb_submit_read(int endpoint, int len)
 {

--- a/src/usb_controller.hpp
+++ b/src/usb_controller.hpp
@@ -47,7 +47,7 @@ public:
   virtual std::string get_usbid() const;
   virtual std::string get_name() const;
 
-  virtual bool parse(uint8_t* data, int len, XboxGenericMsg* msg_out) =0;
+  virtual bool parse(uint8_t* data, int len, XboxGenericMsg* msg_out);
 
   int  usb_find_ep(int direction, uint8_t if_class, uint8_t if_subclass, uint8_t if_protocol);
 


### PR DESCRIPTION
`USBController::parse()` is indirectly called by the destructor, which is not allowed when it is pure virtual, causing a "pure virtual function called" crash. This is also masking a hang when destroying the controller instance.

See inside for details!