### PR TITLE
Basic chatpad support on XBox 360 wireless controller

### DIFF
--- a/src/controller_factory.cpp
+++ b/src/controller_factory.cpp
@@ -58,7 +58,8 @@ ControllerFactory::create(const XPadDevice& dev_type, libusb_device* dev, const 
       break;
 
     case GAMEPAD_XBOX360_WIRELESS:
-      return ControllerPtr(new Xbox360WirelessController(dev, opts.wireless_id, opts.detach_kernel_driver));
+      return ControllerPtr(new Xbox360WirelessController(dev, opts.chatpad, opts.wireless_id,
+                                                         opts.detach_kernel_driver));
 
     case GAMEPAD_FIRESTORM:
       return ControllerPtr(new FirestormDualController(dev, false, opts.detach_kernel_driver));
@@ -121,7 +122,8 @@ ControllerFactory::create_multiple(const XPadDevice& dev_type, libusb_device* de
     case GAMEPAD_XBOX360_WIRELESS:
       for(int wireless_id = 0; wireless_id < 4; ++wireless_id)
       {
-        lst.push_back(ControllerPtr(new Xbox360WirelessController(dev, wireless_id, opts.detach_kernel_driver)));
+        lst.push_back(ControllerPtr(new Xbox360WirelessController(dev, opts.chatpad, wireless_id,
+                                                                  opts.detach_kernel_driver)));
       }
       break;
 

--- a/src/xbox360_wireless_controller.cpp
+++ b/src/xbox360_wireless_controller.cpp
@@ -277,10 +277,10 @@ Xbox360WirelessController::parse(uint8_t* data, int len, XboxGenericMsg* msg_out
       }
       else if (data[0] == 0x00 && data[1] == 0x02 && data[2] == 0x00 && data[3] == 0xf0)
       { // Chatpad
-        if (m_chatpad && m_chatpad_lastpacket != (uint32_t)(data[24] << 24 | data[25] << 16 | data[26] << 24 | data[27]))
+        if (m_chatpad && m_chatpad_lastpacket != static_cast<uint32_t>(data[24] << 24 | data[25] << 16 | data[26] << 24 | data[27]))
         {
           log_debug("chatpad: " << raw2str(data+24, 5));
-          m_chatpad_lastpacket = (uint32_t)(data[24] << 24 | data[25] << 16 | data[26] << 24 | data[27]); // skip dup packet
+          m_chatpad_lastpacket = static_cast<uint32_t>(data[24] << 24 | data[25] << 16 | data[26] << 24 | data[27]); // skip dup packet
 
           if (data[24] == 0xf0 && data[25] == 0x03)
           { // wake up chatpad and release all keys

--- a/src/xbox360_wireless_controller.cpp
+++ b/src/xbox360_wireless_controller.cpp
@@ -35,7 +35,12 @@ Xbox360WirelessController::Xbox360WirelessController(libusb_device* dev, bool ch
   m_endpoint(),
   m_interface(),
   m_battery_status(),
-  m_serial()
+  m_serial(),
+  m_chatpad(),
+  m_chatpad_next(),
+  m_chatpad_timeout(),
+  m_uinput(),
+  m_chatpad_lastpacket()
 {
   // FIXME: A little bit of a hack
   m_is_active = false;
@@ -272,10 +277,10 @@ Xbox360WirelessController::parse(uint8_t* data, int len, XboxGenericMsg* msg_out
       }
       else if (data[0] == 0x00 && data[1] == 0x02 && data[2] == 0x00 && data[3] == 0xf0)
       { // Chatpad
-        if (m_chatpad && m_chatpad_lastpacket != *(uint32_t *)(data+24))
+        if (m_chatpad && m_chatpad_lastpacket != (uint32_t)(data[24] << 24 | data[25] << 16 | data[26] << 24 | data[27]))
         {
           log_debug("chatpad: " << raw2str(data+24, 5));
-          m_chatpad_lastpacket = *(uint32_t *)(data+24); // skip dup packet
+          m_chatpad_lastpacket = (uint32_t)(data[24] << 24 | data[25] << 16 | data[26] << 24 | data[27]); // skip dup packet
 
           if (data[24] == 0xf0 && data[25] == 0x03)
           { // wake up chatpad and release all keys

--- a/src/xbox360_wireless_controller.hpp
+++ b/src/xbox360_wireless_controller.hpp
@@ -36,8 +36,8 @@ private:
   int  m_battery_status;
   std::string m_serial;
   bool m_chatpad;
-  time_t m_chatpad_next;
-  int m_chatpad_timeout;
+  bool m_chatpad_pending;
+  guint m_chatpad_timeout_gid;
   std::auto_ptr<LinuxUinput> m_uinput;
   uint32_t m_chatpad_lastpacket;
   uint8_t m_chatpad_laststroke[3];
@@ -57,6 +57,12 @@ private:
   Xbox360WirelessController (const Xbox360WirelessController&);
   Xbox360WirelessController& operator= (const Xbox360WirelessController&);
   void chatpad_send(uint8_t cmd);
+  void chatpad_release();
+  bool chatpad_timeout_check();
+  static gboolean chatpad_timeout_cb(gpointer data)
+  {
+    return static_cast<Xbox360WirelessController *>(data)->chatpad_timeout_check();
+  }
 };
 
 #endif

--- a/src/xbox360_wireless_controller.hpp
+++ b/src/xbox360_wireless_controller.hpp
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "usb_controller.hpp"
+#include "linux_uinput.hpp"
 
 struct XboxGenericMsg;
 struct XPadDevice;
@@ -34,9 +35,16 @@ private:
   int  m_interface;
   int  m_battery_status;
   std::string m_serial;
+  bool m_chatpad;
+  time_t m_chatpad_next;
+  int m_chatpad_timeout;
+  std::auto_ptr<LinuxUinput> m_uinput;
+  uint32_t m_chatpad_lastpacket;
+  uint8_t m_chatpad_laststroke[3];
+  uint8_t m_chatpad_keymap[256];
 
 public:
-  Xbox360WirelessController(libusb_device* dev, int controller_id, bool try_detach);
+  Xbox360WirelessController(libusb_device* dev, bool chatpad, int controller_id, bool try_detach);
   virtual ~Xbox360WirelessController();
 
   bool parse(uint8_t* data, int len, XboxGenericMsg* msg_out);
@@ -48,6 +56,7 @@ public:
 private:
   Xbox360WirelessController (const Xbox360WirelessController&);
   Xbox360WirelessController& operator= (const Xbox360WirelessController&);
+  void chatpad_send(uint8_t cmd);
 };
 
 #endif


### PR DESCRIPTION
controller_factory.cpp is modified to send chatpad option to
Xbox360WirelessController constructor.
If chatpad option is enabled, LinuxUinput would be instantiated in the
way similar to implementation in chatpad.cpp. But class Chatpad is
tightly coupled with usb communication, the implementation could not be
reused. Defines in chatpad.hpp are reused.
Keymap is slightly altered.
Currently leds on chatpad is not supported.