### PR TITLE
Added "unofficial" AKA "fake" wireless XBox360 receiver, USB ID 045e:02a9

### DIFF
--- a/src/xpad_device.cpp
+++ b/src/xpad_device.cpp
@@ -113,6 +113,7 @@ XPadDevice xpad_devices[] = {
   { GAMEPAD_XBOX360,          0x15e4, 0x3f10, "Batarang Xbox 360 controller" },
   { GAMEPAD_XBOX360_WIRELESS, 0x045e, 0x0291, "Xbox 360 Wireless Receiver (XBOX)" }, // RF Module from the Xbox360
   { GAMEPAD_XBOX360_WIRELESS, 0x045e, 0x0719, "Xbox 360 Wireless Receiver" }, // official Wireless Receiver
+  { GAMEPAD_XBOX360_WIRELESS, 0x045e, 0x02a9, "Xbox 360 Wireless Receiver (Unofficial)" }, // "Fake" (but fully compatible) Wireless Receiver
   { GAMEPAD_XBOX360,          0x24c6, 0x5000, "Razer Atrox Arcade Stick" },
   { GAMEPAD_XBOX360,          0x1689, 0xfd00, "Razer Onza Tournament Edition" },
   { GAMEPAD_XBOX360,          0x1689, 0xfd01, "Razer Onza Classic Edition" },


### PR DESCRIPTION
This receiver is not Microsoft original, though "mimics" MS USB Vendor ID; still perfectly compatible.